### PR TITLE
Add radio type and fixed mime type support and theme support

### DIFF
--- a/plugin_playback_guiplayer/__init__.py
+++ b/plugin_playback_guiplayer/__init__.py
@@ -69,7 +69,7 @@ class GuiPlayerService(AudioBackend):
             # Assume track_data[3] is the theme
             # Check if its available
             if len(track_data) > 2:
-                theme = track_data[3]
+                theme = track_data[2]
             else:
                 theme = None
 

--- a/plugin_playback_guiplayer/__init__.py
+++ b/plugin_playback_guiplayer/__init__.py
@@ -65,7 +65,13 @@ class GuiPlayerService(AudioBackend):
             track = track_data[0]
             mime = track_data[1]
             mime = mime.split('/')
-            theme = track_data[2]
+
+            # Assume track_data[3] is the theme
+            # Check if its available
+            if len(track_data) > 2:
+                theme = track_data[3]
+            else:
+                theme = None
 
             if "type" in mime[0] and "video" in mime[1]:
                 mime = ["video", "type"]

--- a/plugin_playback_guiplayer/__init__.py
+++ b/plugin_playback_guiplayer/__init__.py
@@ -66,7 +66,7 @@ class GuiPlayerService(AudioBackend):
             mime = track_data[1]
             mime = mime.split('/')
 
-            # Assume track_data[3] is the theme
+            # Assume track_data[2] is the theme
             # Check if its available
             if len(track_data) > 2:
                 theme = track_data[2]


### PR DESCRIPTION
#### Description
- Adds support for fixed mime types that Skills can send to open that specific player type ["type/video", "type/audio", "type/radio"]
- Adds support for getting theme from play() metadata and forwarding it to playback skill if available
- Adds support to display radio type

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
For Testing: https://github.com/MycroftAI/skill-npr-news/pull/120
Requires: https://github.com/MycroftAI/skill-playback-control/pull/49

#### CLA
- [x] Yes